### PR TITLE
feat: allow specify content type while uploading a new object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@
 # The .vscode folder contains launch configuration and tasks you configure in
 # VS Code which you may wish to be included in version control, so this line
 # is commented out by default.
-#.vscode/
+.vscode/
 
 # Flutter/Dart/Pub related
 **/doc/api/
@@ -28,6 +28,7 @@
 .packages
 .pub-cache/
 .pub/
+.fvm/
 build/
 
 # Android related

--- a/lib/src/policy.dart
+++ b/lib/src/policy.dart
@@ -47,6 +47,7 @@ class Policy {
   "conditions": [
     {"bucket": "${this.bucket}"},
     ["starts-with", "\$key", "${this.key}"],
+    ["starts-with", "\$Content-Type", ""],
     {"acl": "${aclToString(acl)}"},
     ["content-length-range", 1, ${this.maxFileSize}],
     {"x-amz-credential": "${this.credential}"},


### PR DESCRIPTION
Since uploaded objects always have a `binary/octet-stream` content type.

This PR Add a rule to the Policy to allow users to specify object content type while uploading a new object.