### PR TITLE
adds support for custom metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ AwsS3.uploadFile(
   secretKey: "xxxxxxxxxxxxxxxxxxxxxxxxxx",
   file: File("path_to_file"),
   bucket: "bucket_name",
-  region: "us-east-2"
+  region: "us-east-2",
+  metadata: {"test": "test"} // optional
 );
 ```

--- a/lib/aws_s3_upload.dart
+++ b/lib/aws_s3_upload.dart
@@ -50,7 +50,16 @@ class AwsS3 {
     Map<String, String>? metadata,
   }) async {
     final endpoint = 'https://$bucket.s3.$region.amazonaws.com';
-    final uploadKey = key ?? '$destDir/${filename ?? path.basename(file.path)}';
+
+    var uploadKey;
+
+    if (key != null) {
+      return key;
+    } else if (destDir.isNotEmpty) {
+      return '$destDir/${filename ?? path.basename(file.path)}';
+    } else {
+      uploadKey = '${filename ?? path.basename(file.path)}';
+    }
 
     final stream = http.ByteStream(Stream.castFrom(file.openRead()));
     final length = await file.length();

--- a/lib/aws_s3_upload.dart
+++ b/lib/aws_s3_upload.dart
@@ -44,6 +44,9 @@ class AwsS3 {
 
     /// The content-type of file to upload. defaults to binary/octet-stream.
     String contentType = 'binary/octet-stream',
+
+    /// Additional metadata to be attached to the upload
+    Map<String, dynamic>? metadata,
   }) async {
     final endpoint = 'https://$bucket.s3.$region.amazonaws.com';
     final uploadKey = key ?? '$destDir/${filename ?? path.basename(file.path)}';
@@ -71,6 +74,12 @@ class AwsS3 {
     req.fields['Policy'] = policy.encode();
     req.fields['X-Amz-Signature'] = signature;
     req.fields['Content-Type'] = contentType;
+
+    if (metadata != null) {
+      for (var k in metadata.keys) {
+        req.fields['x-amz-meta-${k}'] = metadata[k];
+      }
+    }
 
     try {
       final res = await req.send();

--- a/lib/aws_s3_upload.dart
+++ b/lib/aws_s3_upload.dart
@@ -54,9 +54,9 @@ class AwsS3 {
     var uploadKey;
 
     if (key != null) {
-      return key;
+      uploadKey = key;
     } else if (destDir.isNotEmpty) {
-      return '$destDir/${filename ?? path.basename(file.path)}';
+      uploadKey = '$destDir/${filename ?? path.basename(file.path)}';
     } else {
       uploadKey = '${filename ?? path.basename(file.path)}';
     }

--- a/lib/src/policy.dart
+++ b/lib/src/policy.dart
@@ -13,14 +13,30 @@ class Policy {
   String credential;
   String datetime;
   int maxFileSize;
+  Map<String, dynamic>? metadata;
 
-  Policy(this.key, this.bucket, this.datetime, this.expiration, this.credential,
-      this.maxFileSize, this.acl,
-      {this.region = 'us-east-2'});
+  Policy(
+    this.key,
+    this.bucket,
+    this.datetime,
+    this.expiration,
+    this.credential,
+    this.maxFileSize,
+    this.acl, {
+    this.region = 'us-east-2',
+    this.metadata,
+  });
 
-  factory Policy.fromS3PresignedPost(String key, String bucket,
-      String accessKeyId, int expiryMinutes, int maxFileSize, ACL acl,
-      {String region = 'us-east-2'}) {
+  factory Policy.fromS3PresignedPost(
+    String key,
+    String bucket,
+    String accessKeyId,
+    int expiryMinutes,
+    int maxFileSize,
+    ACL acl, {
+    String region = 'us-east-2',
+    Map<String, dynamic>? metadata,
+  }) {
     final datetime = SigV4.generateDatetime();
     final expiration = (DateTime.now())
         .add(Duration(minutes: expiryMinutes))
@@ -31,8 +47,17 @@ class Policy {
     final cred =
         '$accessKeyId/${SigV4.buildCredentialScope(datetime, region, 's3')}';
 
-    return Policy(key, bucket, datetime, expiration, cred, maxFileSize, acl,
-        region: region);
+    return Policy(
+      key,
+      bucket,
+      datetime,
+      expiration,
+      cred,
+      maxFileSize,
+      acl,
+      region: region,
+      metadata: metadata,
+    );
   }
 
   String encode() {
@@ -52,8 +77,9 @@ class Policy {
     ["content-length-range", 1, ${this.maxFileSize}],
     {"x-amz-credential": "${this.credential}"},
     {"x-amz-algorithm": "AWS4-HMAC-SHA256"},
-    {"x-amz-date": "${this.datetime}" }
-  ]
+    {"x-amz-date": "${this.datetime}"},
+    ${jsonEncode(metadata)},
+  ],
 }
 ''';
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   charcode:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -70,7 +70,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -101,28 +101,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: "direct main"
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   pedantic:
     dependency: transitive
     description:
@@ -130,6 +130,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.11.0"
+  recase:
+    dependency: "direct main"
+    description:
+      name: recase
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.1.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -141,7 +148,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -162,21 +169,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,12 +8,12 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
+  amazon_cognito_identity_dart_2: ^1.0.3
   flutter:
     sdk: flutter
-
-  amazon_cognito_identity_dart_2: ^1.0.3
   http: ^0.13.3
   path: ^1.8.0
+  recase: ^4.1.0
 
 dev_dependencies:
   flutter_test:
@@ -21,6 +21,5 @@ dev_dependencies:
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
-
 # The following section is specific to Flutter.
-flutter:
+flutter: null


### PR DESCRIPTION
This adds support for adding custom metadata to an upload.

In addition, it fixes an issue where unless `destDir` is specified, it puts everything in a folder called `/`, which isn't actually the root of the bucket.