### PR TITLE
http method option

### DIFF
--- a/lib/aws_s3_upload.dart
+++ b/lib/aws_s3_upload.dart
@@ -46,6 +46,9 @@ class AwsS3 {
     /// The content-type of file to upload. defaults to binary/octet-stream.
     String contentType = 'binary/octet-stream',
 
+    /// HTTP method option. default to POST.
+    String method = 'POST',
+
     /// Additional metadata to be attached to the upload
     Map<String, String>? metadata,
   }) async {
@@ -65,7 +68,7 @@ class AwsS3 {
     final length = await file.length();
 
     final uri = Uri.parse(endpoint);
-    final req = http.MultipartRequest("POST", uri);
+    final req = http.MultipartRequest(method, uri);
     final multipartFile = http.MultipartFile('file', stream, length,
         filename: path.basename(file.path));
 


### PR DESCRIPTION
optional for 

Because, it supports `GET` `HEAD` only...

https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteEndpoints.html

Refer to: other http request method #19